### PR TITLE
[nae] Change path to expando.c script

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -322,7 +322,7 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
     // file of OpenSSL, `opensslconf.h`, and then dump out everything it defines
     // as our own #[cfg] directives. That way the `ossl10x.rs` bindings can
     // account for compile differences and such.
-    println!("cargo:rerun-if-changed=build/expando.c");    
+    println!("cargo:rerun-if-changed=build/expando.c");
     let mut gcc = cc::Build::new();
     gcc.includes(include_dirs);
     let expanded = match gcc.file(expando_path).try_expand() {

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -322,10 +322,7 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
     // file of OpenSSL, `opensslconf.h`, and then dump out everything it defines
     // as our own #[cfg] directives. That way the `ossl10x.rs` bindings can
     // account for compile differences and such.
-    println!("cargo:rerun-if-changed=build/expando.c");
-    let lib_path =
-        PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
-    
+    println!("cargo:rerun-if-changed=build/expando.c");    
     let mut gcc = cc::Build::new();
     gcc.includes(include_dirs);
     let expanded = match gcc.file(expando_path).try_expand() {

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -213,17 +213,6 @@ fn main() {
     }
     println!("cargo:include={}", include_dir.to_string_lossy());
 
-    // let target = env::var("TARGET").unwrap();
-    // let (lib_dirs, include_dir) = find_openssl(&target);
-
-    // let version =  if target.contains("android") {
-    //     println!("cargo:rustc-cfg=openssl");
-    //     println!("cargo:version=111"); // Assume a reasonable OpenSSL version
-    //     Version::Openssl11x
-    // } else {
-    //     postprocess(&[include_dir])
-    // };
-
     let version = postprocess(&[include_dir]);
 
     let libs_env = env("OPENSSL_LIBS");

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -213,6 +213,17 @@ fn main() {
     }
     println!("cargo:include={}", include_dir.to_string_lossy());
 
+    // let target = env::var("TARGET").unwrap();
+    // let (lib_dirs, include_dir) = find_openssl(&target);
+
+    // let version =  if target.contains("android") {
+    //     println!("cargo:rustc-cfg=openssl");
+    //     println!("cargo:version=111"); // Assume a reasonable OpenSSL version
+    //     Version::Openssl11x
+    // } else {
+    //     postprocess(&[include_dir])
+    // };
+
     let version = postprocess(&[include_dir]);
 
     let libs_env = env("OPENSSL_LIBS");
@@ -304,6 +315,13 @@ fn postprocess(include_dirs: &[PathBuf]) -> Version {
 /// version string of OpenSSL.
 #[allow(clippy::unusual_byte_groupings)]
 fn validate_headers(include_dirs: &[PathBuf]) -> Version {
+    // NOTE: When building Tauri apps, we update `rules_rust()` to not change the working 
+    // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
+    // root. In this case we're
+    // Try multiple locations for expando.c to handle both regular builds and Bazel builds
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let mut expando_path = manifest_dir.join("build/expando.c");
+
     // This `*-sys` crate only works with OpenSSL 1.0.1, 1.0.2, 1.1.0, 1.1.1 and 3.0.0.
     // To correctly expose the right API from this crate, take a look at
     // `opensslv.h` to see what version OpenSSL claims to be.
@@ -316,10 +334,12 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
     // file of OpenSSL, `opensslconf.h`, and then dump out everything it defines
     // as our own #[cfg] directives. That way the `ossl10x.rs` bindings can
     // account for compile differences and such.
-    println!("cargo:rerun-if-changed=build/expando.c");
+    let lib_path =
+        PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    
     let mut gcc = cc::Build::new();
     gcc.includes(include_dirs);
-    let expanded = match gcc.file("build/expando.c").try_expand() {
+    let expanded = match gcc.file(expando_path).try_expand() {
         Ok(expanded) => expanded,
         Err(e) => {
             panic!(

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -308,7 +308,7 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
     // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
     // root.
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
-    let mut expando_path = manifest_dir.join("build/expando.c");
+    let expando_path = manifest_dir.join("build/expando.c");
 
     // This `*-sys` crate only works with OpenSSL 1.0.1, 1.0.2, 1.1.0, 1.1.1 and 3.0.0.
     // To correctly expose the right API from this crate, take a look at

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -317,8 +317,7 @@ fn postprocess(include_dirs: &[PathBuf]) -> Version {
 fn validate_headers(include_dirs: &[PathBuf]) -> Version {
     // NOTE: When building Tauri apps, we update `rules_rust()` to not change the working 
     // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
-    // root. In this case we're
-    // Try multiple locations for expando.c to handle both regular builds and Bazel builds
+    // root.
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let mut expando_path = manifest_dir.join("build/expando.c");
 

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -322,6 +322,7 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
     // file of OpenSSL, `opensslconf.h`, and then dump out everything it defines
     // as our own #[cfg] directives. That way the `ossl10x.rs` bindings can
     // account for compile differences and such.
+    println!("cargo:rerun-if-changed=build/expando.c");
     let lib_path =
         PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     


### PR DESCRIPTION
# Description
Since we execute from the sandbox root in `rules_rust()`, we need to change from a relative path to explicitly acting in the directory with the `openssl-sys` `cargo.toml` to resolve the `exapndo.c` dependency.

Changes based on this [thread](https://nianticspatial.slack.com/archives/C08V3FY26HX/p1759268522367389?thread_ts=1758908683.714799&cid=C08V3FY26HX)

# Testing
Before the change, and with https://github.com/8thwall/code8/pull/4733:
```
Could not find openssl via pkg-config:
pkg-config has not been configured to support cross-compilation.

Install a sysroot for the target platform and configure it via
PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_PATH, or install a
cross-compiling wrapper for pkg-config and set it via
PKG_CONFIG environment variable.

cargo:warning=Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the compilation process. See stderr section below for further information.

--stderr:


Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

Make sure you also have the development packages of openssl installed.
For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

If you're in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

$HOST = aarch64-apple-darwin
$TARGET = aarch64-linux-android
openssl-sys = 0.0.0



Target //c8/html-shell-tauri:lib failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 6.640s, Critical Path: 0.51s
INFO: 10 processes: 3 disk cache hit, 7 internal.
```

If we just simply point the crate to use a locally/forked version of `openssl-sys` without changing the path logic here we get:
```
cargo:warning=clang: error: no such file or directory: 'build/expando.c'
cargo:warning=clang: error: no input files

--stderr:
thread 'main' panicked at external/tauri-deps__openssl-sys-0.9.109/build/main.rs:325:13:

Header expansion error:
Error { kind: ToolExecError, message: "command did not execute successfully (status code exit status: 1): LC_ALL=\"C\" \"/private/var/tmp/_bazel_akash/cf7c73dc90e51b86f665ec6f6040626f/sandbox/darwin-sandbox/9352/execroot/_main/bzl/crosstool/clang-android-wrapper.sh\" \"-O0\" \"-DANDROID\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-gdwarf-2\" \"-fno-omit-frame-pointer\" \"-I\" \"/private/var/tmp/_bazel_akash/cf7c73dc90e51b86f665ec6f6040626f/sandbox/darwin-sandbox/9352/execroot/_main/bazel-out/arm64-v8a-fastbuild/bin/external/openssl/openssl-rust-complete/include\" \"-std=c11\" \"-target\" \"aarch64-linux-android24\" \"-Wno-invalid-command-line-argument\" \"-Wno-unused-command-line-argument\" \"-ffunction-sections\" \"-funwind-tables\" \"-fstack-protector-strong\" \"-no-canonical-prefixes\" \"-fsigned-char\" \"-DANDROID\" \"-D__BIONIC__\" \"-fcolor-diagnostics\" \"-no-canonical-prefixes\" \"-Wno-builtin-macro-redefined\" \"-D__DATE__=\\\"redacted\\\"\" \"-D__TIMESTAMP__=\\\"redacted\\\"\" \"-D__TIME__=\\\"redacted\\\"\" \"-g2\" \"-O3\" \"-DNDEBUG\" \"-fPIC\" \"-E\" \"build/expando.c\"" }

Failed to find OpenSSL development headers.

You can try fixing this setting the `OPENSSL_DIR` environment variable
pointing to your OpenSSL installation or installing OpenSSL headers package
specific to your distribution:

    # On Ubuntu
    sudo apt-get install pkg-config libssl-dev
    # On Arch Linux
    sudo pacman -S pkgconf openssl
    # On Fedora
    sudo dnf install pkgconf perl-FindBin perl-IPC-Cmd openssl-devel
    # On Alpine Linux
    apk add pkgconf openssl-dev

See rust-openssl documentation for more information:

    https://docs.rs/openssl

stack backtrace:
   0:        0x100f07a20 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::habbf9c4f641febb1
   1:        0x100f49424 - core::fmt::write::ha36a8060c13608ea
   2:        0x100efc530 - std::io::Write::write_fmt::h431832c8ebcc85c9
   3:        0x100f0a0e8 - std::panicking::default_hook::{{closure}}::h4aa1f60327dfff6a
   4:        0x100f09c98 - std::panicking::default_hook::h4ebc6eb4ae179807
   5:        0x100f0ad04 - std::panicking::rust_panic_with_hook::h6a84efe4dcab239c
   6:        0x100f0a730 - std::panicking::begin_panic_handler::{{closure}}::h5eef292190467fef
   7:        0x100f07ee4 - std::sys::backtrace::__rust_end_short_backtrace::hd7e7925203f20af9
   8:        0x100f0a3f8 - _rust_begin_unwind
   9:        0x100f45bcc - core::panicking::panic_fmt::h410d3f147658259b
  10:        0x100e65924 - build_script_main::postprocess::h44bcc84677a6b080
  11:        0x100e63184 - build_script_main::main::h6e10dbb65c01dcea
  12:        0x100e6e870 - std::sys::backtrace::__rust_begin_short_backtrace::h7569684aca3dec46
  13:        0x100e6e858 - std::rt::lang_start::{{closure}}::h33b7d4cb027ef41a
  14:        0x100eef570 - std::rt::lang_start_internal::h9e88109c8deb8787
  15:        0x100e65d00 - _main

Target //c8/html-shell-tauri:lib failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 169.098s, Critical Path: 0.74s
INFO: 15 processes: 4 disk cache hit, 11 internal.
ERROR: Build did NOT complete successfully
```


After (passes `openssl-sys` compilation):
```
error[E0425]: cannot find value `handle` in this scope
  --> bazel-out/arm64-v8a-fastbuild/bin/c8/html-shell-tauri/plugins/tauri-plugin-native-app-export/src/mobile.rs:16:24
   |
16 |     Ok(NativeAppExport(handle))
   |                        ^^^^^^ not found in this scope
   |
help: consider importing this function
   |
1  + use tauri::async_runtime::handle;
   |

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0425`.
Target //c8/html-shell-tauri:lib failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 9.117s, Critical Path: 0.66s
INFO: 4 processes: 3 internal, 1 darwin-sandbox.
ERROR: Build did NOT complete successfully
```  